### PR TITLE
build: fix prepare release unable to push

### DIFF
--- a/prepare-release.dockerfile
+++ b/prepare-release.dockerfile
@@ -9,6 +9,7 @@ COPY . ./
 CMD npm install && \
   git config --global user.email "$GIT_USER_EMAIL" && \
   git config --global user.name "$GIT_USER_NAME" && \
+  git pull origin master && \
   npm run release && \
   git add package*.json CHANGELOG.md && \
   git push origin master && \


### PR DESCRIPTION
When there are two releases running at the same time, one of the will
push a new version and the other one will get an error trying to push
the same version too. Pulling right before this should reduce the chance
of this race condition.