### PR TITLE
ci(#55): fix wrong coverage folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules
 dist
 
-coverage
+.coverage
 cypress/videos
 cypress/screenshots
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,4 +8,5 @@ module.exports = {
   testEnvironment: "jsdom",
   setupFilesAfterEnv: ["<rootDir>/src/setupTests.ts"],
   collectCoverage: true,
+  coverageDirectory: ".coverage",
 };

--- a/prepare-release.dockerignore
+++ b/prepare-release.dockerignore
@@ -4,6 +4,6 @@ dist
 
 *stats.json
 
-coverage
+.coverage
 cypress/videos
 cypress/screenshots

--- a/release.dockerignore
+++ b/release.dockerignore
@@ -5,7 +5,7 @@ dist
 *stats.json
 .git
 
-coverage
+.coverage
 cypress/videos
 cypress/screenshots
 

--- a/run-local.dockerignore
+++ b/run-local.dockerignore
@@ -5,7 +5,7 @@ dist
 *stats.json
 .git
 
-coverage
+.coverage
 cypress/videos
 cypress/screenshots
 

--- a/test.dockerignore
+++ b/test.dockerignore
@@ -5,7 +5,7 @@ dist
 *stats.json
 .git
 
-coverage
+.coverage
 cypress/videos
 cypress/screenshots
 


### PR DESCRIPTION
Codecov expects '.coverage' by default. We could have set it to the
existing 'coverage' folder, but making it a hidden folder is not a bad
idea.