### PR TITLE
build(#55): mount coverage volume before test

### DIFF
--- a/test.dockerfile
+++ b/test.dockerfile
@@ -1,9 +1,11 @@
 FROM cypress/base:14.7.0
 
+WORKDIR /test
+
 COPY package*.json ./
 
 RUN npm install
 
 COPY . .
 
-RUN npm run lint && npm run test:ci
+CMD npm run lint && npm run test:ci

--- a/test.sh
+++ b/test.sh
@@ -8,4 +8,6 @@ export DOCKER_BUILDKIT=1
 
 docker build -t anime-suupu/test-ci -f test.dockerfile .
 
-docker run --rm anime-suupu/test-ci
+docker run --rm \
+  -v ${PWD}/.coverage:/test/.coverage \
+  anime-suupu/test-ci


### PR DESCRIPTION
This should fix the issue of Codecov not seeing any reports. The tests
are running inside docker on ci, therefore a volume needs to be mounted,
otherwise the report will not be there.