### PR TITLE
ci(66): fix changelog missing commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@main
         with:
           ref: "master"
+          fetch-depth: "1"
       - name: Prepare release
         env:
           GIT_USER_EMAIL: ${{ secrets.GIT_USER_EMAIL }}


### PR DESCRIPTION
standard-version is not adding the commits to the new version. This is
probably because prepare-release wasn't checking out the whole history,
but just the last commit.