### PR TITLE
ci(#66): fix changelog missing commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@main
         with:
           ref: "master"
-          fetch-depth: "1"
+          fetch-depth: "0"
       - name: Prepare release
         env:
           GIT_USER_EMAIL: ${{ secrets.GIT_USER_EMAIL }}


### PR DESCRIPTION
The last attempt set 'fetch-depth: 1' by mistake, which is exactly what
was there before (default value).