### PR TITLE
Revert "build: upgrade to node 16"

### DIFF
--- a/prepare-release.dockerfile
+++ b/prepare-release.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.4.2-alpine3.14
+FROM node:14.7-alpine3.12
 
 RUN apk add git
 

--- a/release.dockerfile
+++ b/release.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.4.2-alpine3.14
+FROM node:14.7-alpine3.12
 
 RUN apk add git && \
   npm install -g heroku

--- a/run-local.dockerfile
+++ b/run-local.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.4.2-alpine3.14
+FROM node:14.7-alpine3.12
 
 WORKDIR /app
 


### PR DESCRIPTION
This reverts commit fb13f0a94ef7b8022ab92d12763c7b28e5361665.

Breaks when releasing to heroku:

Error: Cannot find module '@heroku/buildpack-registry'
Require stack:
- /usr/local/lib/node_modules/heroku/node_modules/@heroku-cli/plugin-buildpacks/lib/buildpacks.js
- /usr/local/lib/node_modules/heroku/node_modules/@heroku-cli/plugin-buildpacks/lib/commands/buildpacks/clear.js
- /usr/local/lib/node_modules/heroku/node_modules/@oclif/config/lib/plugin.js
- /usr/local/lib/node_modules/heroku/node_modules/@oclif/config/lib/config.js
- /usr/local/lib/node_modules/heroku/node_modules/@oclif/config/lib/index.js
- /usr/local/lib/node_modules/heroku/node_modules/@oclif/command/lib/command.js
- /usr/local/lib/node_modules/heroku/node_modules/@oclif/command/lib/index.js
- /usr/local/lib/node_modules/heroku/bin/run
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:927:15)
    at Function.Module._load (node:internal/modules/cjs/loader:772:27)
    at Module.require (node:internal/modules/cjs/loader:999:19)
    at require (node:internal/modules/cjs/helpers:93:18)
    at Object.<anonymous> (/usr/local/lib/node_modules/heroku/node_modules/@heroku-cli/plugin-buildpacks/lib/buildpacks.js:4:30)
    at Module._compile (node:internal/modules/cjs/loader:1095:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1124:10)
    at Module.load (node:internal/modules/cjs/loader:975:32)
    at Function.Module._load (node:internal/modules/cjs/loader:816:12)
    at Module.require (node:internal/modules/cjs/loader:999:19)